### PR TITLE
added user_module functionality

### DIFF
--- a/pytomo3d/window/tests/test_window.py
+++ b/pytomo3d/window/tests/test_window.py
@@ -136,7 +136,6 @@ def test_update_user_levels():
     assert isinstance(config.s2n_limit, np.ndarray)
 
 
-
 def test_plot_window_figure(tmpdir):
     reset_matplotlib()
 

--- a/pytomo3d/window/tests/test_window.py
+++ b/pytomo3d/window/tests/test_window.py
@@ -113,6 +113,30 @@ def test_window_on_stream():
     assert len(windows) > 0
 
 
+def test_update_user_levels():
+    from pytomo3d.window import window
+    import numpy as np
+    obs_tr = read(obsfile)
+    syn_tr = read(synfile)
+
+    config_file = os.path.join(DATA_DIR, "window", "27_60.BHZ.config.yaml")
+    config = win.load_window_config_yaml(config_file)
+
+    cat = readEvents(quakeml)
+    inv = read_inventory(staxml)
+
+    user_module = "pytomo3d.window.tests.user_module_example"
+    config = window.update_user_levels(user_module, config, inv, cat,
+                                       obs_tr[0], syn_tr[0])
+
+    assert isinstance(config.stalta_waterlevel, np.ndarray)
+    assert isinstance(config.tshift_acceptance_level, np.ndarray)
+    assert isinstance(config.dlna_acceptance_level, np.ndarray)
+    assert isinstance(config.cc_acceptance_level, np.ndarray)
+    assert isinstance(config.s2n_limit, np.ndarray)
+
+
+
 def test_plot_window_figure(tmpdir):
     reset_matplotlib()
 

--- a/pytomo3d/window/tests/user_module_example.py
+++ b/pytomo3d/window/tests/user_module_example.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from obspy.geodetics import gps2dist_azimuth
 from obspy.geodetics import calcVincentyInverse
+
 
 def get_dist_in_km(station, event, obsd):
     """
@@ -19,16 +19,17 @@ def get_dist_in_km(station, event, obsd):
     evlon = event.events[0].origins[0].longitude
 
     dist = calcVincentyInverse(station_coor["latitude"],
-                               station_coor["longitude"], evlat, evlon)[0] / 1000
+                               station_coor["longitude"],
+                               evlat, evlon)[0] / 1000
 
     return dist
+
 
 def get_time_array(obsd, event):
     stats = obsd.stats
     dt = stats.delta
     npts = stats.npts
     start = stats.starttime - event.events[0].origins[0].time
-    print(start, start+npts*dt+dt, dt )
     return np.arange(start, start+npts*dt, dt)
 
 
@@ -37,7 +38,6 @@ def generate_user_levels(config, station, event, obsd, synt):
     """Returns a list of acceptance levels
     """
     stats = obsd.stats
-    dt = stats.delta
     npts = stats.npts
 
     base_water_level = config.stalta_waterlevel
@@ -59,8 +59,6 @@ def generate_user_levels(config, station, event, obsd, synt):
     r_time = dist/r_vel
 
     times = get_time_array(obsd, event)
-    print(times)
-    assert len(times) == npts
 
     for i, time in enumerate(times):
         if time > r_time:

--- a/pytomo3d/window/tests/user_module_example.py
+++ b/pytomo3d/window/tests/user_module_example.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+from obspy.geodetics import gps2dist_azimuth
+from obspy.geodetics import calcVincentyInverse
+
+def get_dist_in_km(station, event, obsd):
+    """
+    Returns distance in km
+    """
+    stats = obsd.stats
+    station_coor = station.get_coordinates(".".join([stats.network,
+                                                     stats.station,
+                                                     stats.location,
+                                                     stats.channel[:-1]+"Z"]))
+
+    evlat = event.events[0].origins[0].latitude
+    evlon = event.events[0].origins[0].longitude
+
+    dist = calcVincentyInverse(station_coor["latitude"],
+                               station_coor["longitude"], evlat, evlon)[0] / 1000
+
+    return dist
+
+def get_time_array(obsd, event):
+    stats = obsd.stats
+    dt = stats.delta
+    npts = stats.npts
+    start = stats.starttime - event.events[0].origins[0].time
+    print(start, start+npts*dt+dt, dt )
+    return np.arange(start, start+npts*dt, dt)
+
+
+# raise levels after rayleigh
+def generate_user_levels(config, station, event, obsd, synt):
+    """Returns a list of acceptance levels
+    """
+    stats = obsd.stats
+    dt = stats.delta
+    npts = stats.npts
+
+    base_water_level = config.stalta_waterlevel
+    base_cc = config.cc_acceptance_level
+    base_tshift = config.tshift_acceptance_level
+    base_dlna = config.dlna_acceptance_level
+    base_s2n = config.s2n_limit
+
+    stalta_waterlevel = np.ones(npts)*base_water_level
+    cc = np.ones(npts)*base_cc
+    tshift = np.ones(npts)*base_tshift
+    dlna = np.ones(npts)*base_dlna
+    s2n = np.ones(npts)*base_s2n
+
+    dist = get_dist_in_km(station, event, obsd)
+
+    # Rayleigh
+    r_vel = config.min_surface_wave_velocity
+    r_time = dist/r_vel
+
+    times = get_time_array(obsd, event)
+    print(times)
+    assert len(times) == npts
+
+    for i, time in enumerate(times):
+        if time > r_time:
+            stalta_waterlevel[i] = base_water_level*2.0
+            tshift[i] = base_tshift/3.0
+            cc[i] = 0.95
+            dlna[i] = base_dlna/3.0
+            s2n[i] = 10*base_s2n
+
+    return stalta_waterlevel, tshift, dlna, cc, s2n

--- a/pytomo3d/window/window.py
+++ b/pytomo3d/window/window.py
@@ -107,12 +107,19 @@ def update_user_levels(user_module, config, station, event, obsd, synt):
         # catch the AttributeError.
         generate = user.generate_user_levels
     except ImportError:
-        raise Exception("Could not import the user_function module:", user_module)
+        raise Exception("Could not import the user_function module:",
+                        user_module)
     except AttributeError:
-        raise Exception("Given user module does not have a generate_user_levels method.")
+        raise Exception("Given user module does not have a"
+                        "generate_user_levels method.")
 
-    config_copy = copy.deepcopy(config) # do not give the original config to the user
-    stalta_waterlevel, tshift, dlna, cc, s2n = generate(config_copy, station, event, obsd, synt)
+    # do not give the original config to the user
+    config_copy = copy.deepcopy(config)
+    stalta_waterlevel, tshift, dlna, cc, s2n = generate(config_copy,
+                                                        station,
+                                                        event,
+                                                        obsd,
+                                                        synt)
 
     # Create a new config using new acceptance levels
     new_config = copy.deepcopy(config)
@@ -165,7 +172,8 @@ def window_on_trace(obs_tr, syn_tr, config, station=None,
     # If user gives a user_module, use it to update acceptance levels
     # as arrays.
     if user_module:
-        config = update_user_levels(user_module, config, station, event, obs_tr, syn_tr)
+        config = update_user_levels(user_module, config, station,
+                                    event, obs_tr, syn_tr)
 
     ws = pyflex.WindowSelector(obs_tr, syn_tr, config,
                                event=event, station=station)
@@ -186,7 +194,8 @@ def window_on_trace(obs_tr, syn_tr, config, station=None,
 
 
 def window_on_stream(observed, synthetic, config_dict, station=None,
-                     event=None, user_modules=None, figure_mode=False, figure_dir=None,
+                     event=None, user_modules=None,
+                     figure_mode=False, figure_dir=None,
                      _verbose=False):
     """
     Window selection on a Stream


### PR DESCRIPTION
Hi Wenjie,

I implemented variable acceptance level functionality to emulate the user_function module in FLEXWIN.

User creates a python module (a python file) with a function called "generate_user_levels" and passes it to pytomo3d as a string. This module is imported dynamically and function is called with current config values. User function generates acceptance level parameters as arrays and returns them. And then, config is updated using these arrays.

1. Using function means that you cannot strictly enforce the return value order. This can cause some problems. However, I was not comfortable with manipulating config variable directly in the user function and I think using a class of instead of a function would be overkill.
2. It is a little bit convoluted to calculate station distance to event. Maybe this type of operations can be provided somewhere as utility functions.

I also updated pypaw to include the user_module as an option. This way you can define your user_module in a config file.  I made a pull request for it, too. So, you can see how it can be used in pypaw.

Let me know what you think.

---

 - pytomo3d/window/tests/user_module_example.py is an example user module.
 - pytomo3d/window/window.py:update_user_levels is the main function that generates the new config.