### PR TITLE
Check amplitude in measurement culling process

### DIFF
--- a/pytomo3d/window/filter_windows.py
+++ b/pytomo3d/window/filter_windows.py
@@ -117,24 +117,40 @@ def get_measurements_std(measurements):
     """
     Calculate the mean and standard deviation values from the measurements
     """
-    comp_meas = {}
+    comp_dt_meas = {}
+    comp_dlna_meas = {}
 
     for sta_info in measurements.itervalues():
         for chan, chan_info in sta_info.iteritems():
             comp = chan.split(".")[-1][-1]
+
             dts = [v["dt"] for v in chan_info]
-            if comp not in comp_meas:
-                comp_meas[comp] = []
-            comp_meas[comp].extend(dts)
+            dlnas = [v["dlna"] for v in chan_info]
 
-    means = dict((k, np.mean(v)) for (k, v) in comp_meas.iteritems())
-    stds = dict((k, np.std(v)) for (k, v) in comp_meas.iteritems())
+            if comp not in comp_dt_meas:
+                comp_dt_meas[comp] = []
+            comp_dt_meas[comp].extend(dts)
 
-    print("means of measurements:")
-    pprint(means)
-    print("std of measurements:")
-    pprint(stds)
-    return means, stds
+            if comp not in comp_dlna_meas:
+                comp_dlna_meas[comp] = []
+            comp_dlna_meas[comp].extend(dlnas)
+
+    dt_means = dict((k, np.mean(v)) for (k, v) in comp_dt_meas.iteritems())
+    dt_stds = dict((k, np.std(v)) for (k, v) in comp_dt_meas.iteritems())
+
+    dlna_means = dict((k, np.mean(v)) for (k, v) in comp_dlna_meas.iteritems())
+    dlna_stds = dict((k, np.std(v)) for (k, v) in comp_dlna_meas.iteritems())
+
+    print("means of dt measurements:")
+    pprint(dt_means)
+    print("std of dt measurements:")
+    pprint(dt_stds)
+    print("means of dlna measurements:")
+    pprint(dlna_means)
+    print("std of dlna measurements:")
+    pprint(dlna_stds)
+
+    return dt_means, dt_stds, dlna_means, dlna_stds
 
 
 def get_user_bound(info):
@@ -213,7 +229,8 @@ def filter_windows_on_measurements(windows, measurements, measure_config):
     if len(windows) == 0:
         return {}, {}
 
-    means, stds = get_measurements_std(measurements)
+    dt_means, dt_stds, dlna_means, dlna_stds = \
+        get_measurements_std(measurements)
 
     # get the measurement bounds
     final_bounds = {}

--- a/pytomo3d/window/filter_windows.py
+++ b/pytomo3d/window/filter_windows.py
@@ -185,8 +185,10 @@ def filter_measurements_on_bounds(windows, measurements, bounds):
                              "measurements")
         for win, meas in zip(chan_wins, chan_meas):
             # print("%.2f, %.2f, %.2f" % (meas["dt"], bounds[0], bounds[1]))
-            if (meas["dt"] >= bounds[0]) and (meas["dt"] <= bounds[1]) \
-                and (meas["dlna"] >= bounds[2]) and (meas["dlna"] <= bounds[3] ):
+            if (meas["dt"] >= bounds[0]) \
+                    and (meas["dt"] <= bounds[1]) \
+                    and (meas["dlna"] >= bounds[2]) \
+                    and (meas["dlna"] <= bounds[3]):
                 new_wins.append(win)
                 new_meas.append(meas)
 
@@ -241,9 +243,9 @@ def filter_windows_on_measurements(windows, measurements, measure_config):
         print("-" * 20 + "\nComponent: %s" % comp)
         user_bound = get_user_bound(comp_config[comp])
         dt_std_bound = get_std_bound(dt_means[comp], dt_stds[comp],
-                                  comp_config[comp]["std_ratio"])
+                                     comp_config[comp]["std_ratio"])
         dlna_std_bound = get_std_bound(dlna_means[comp], dlna_stds[comp],
-                                  comp_config[comp]["std_ratio"])
+                                       comp_config[comp]["std_ratio"])
 
         bound = [max(dt_std_bound[0], user_bound[0]),
                  min(dt_std_bound[1], user_bound[1]),

--- a/pytomo3d/window/tests/test_filter_windows.py
+++ b/pytomo3d/window/tests/test_filter_windows.py
@@ -101,15 +101,15 @@ def test_get_measurements_std():
          "Z": np.std([1, 2, -1.5, 2, -5, -0.2, 0.8, -1.6, 1.6, 0.9])}
 
     _true_dlna_mean = \
-        {"R": np.mean([1.0, -1.0, 1.0, 1.0, -0.8]),
-         "T": np.mean([0.3, 0.3, -0.7]),
+        {"R": np.mean([0.7, -0.7, 0.6, 1.0, -0.8]),
+         "T": np.mean([0.9, 0.3, -0.7]),
          "Z": np.mean([0.6, 0.4, -0.5, 1.2, -1.5, -0.2, 0.8, -0.6, 1.1, 0.9])}
     _true_dlna_stds = \
-        {"R": np.mean([1.0, -1.0, 1.0, 1.0, -0.8]),
-         "T": np.mean([0.3, 0.3, -0.7]),
-         "Z": np.mean([0.6, 0.4, -0.5, 1.2, -1.5, -0.2, 0.8, -0.6, 1.1, 0.9])}
+        {"R": np.std([0.7, -0.7, 0.6, 1.0, -0.8]),
+         "T": np.std([0.9, 0.3, -0.7]),
+         "Z": np.std([0.6, 0.4, -0.5, 1.2, -1.5, -0.2, 0.8, -0.6, 1.1, 0.9])}
 
-    for comp in means:
+    for comp in dt_means:
         npt.assert_array_almost_equal(dt_means[comp], _true_dt_mean[comp])
         npt.assert_array_almost_equal(dt_stds[comp], _true_dt_stds[comp])
         npt.assert_array_almost_equal(dlna_means[comp], _true_dlna_mean[comp])
@@ -118,36 +118,48 @@ def test_get_measurements_std():
 
 
 def test_get_user_bound():
-    info = {"tshift_acceptance_level": 3, "tshift_reference": 0}
+    info = {"tshift_acceptance_level": 3, "tshift_reference": 0,
+            "dlna_acceptance_level": 0.8, "dlna_reference": 0.0}
     v = fw.get_user_bound(info)
-    npt.assert_array_almost_equal(v, [-3, 3])
+    npt.assert_array_almost_equal(v, [-3, 3, -0.8, 0.8])
 
-    info = {"tshift_acceptance_level": 10, "tshift_reference": -1}
+    info = {"tshift_acceptance_level": 10, "tshift_reference": -1,
+            "dlna_acceptance_level": 0.6, "dlna_reference": 0.2}
     v = fw.get_user_bound(info)
-    npt.assert_array_almost_equal(v, [-11, 9])
+    npt.assert_array_almost_equal(v, [-11, 9, -0.4, 0.8])
 
 
 def test_filter_measurements_on_bounds():
-    bounds = {"R": [-1.1, 1.1], "T": [-1.1, 1.1], "Z": [-1.1, 1.1]}
+    bounds = {"R": [-1.1, 1.1, -0.8, 0.8],
+              "T": [-1.1, 1.1, -0.8, 0.8],
+              "Z": [-1.1, 1.1, -0.8, 0.8]}
 
     v, m = fw.filter_measurements_on_bounds(windows, measures, bounds)
     assert v["II.AAK"]["II.AAK..BHR"] == windows["II.AAK"]["II.AAK..BHR"]
     assert "II.AAK..BHT" not in v["II.AAK"]
     assert len(v["II.AAK"]["II.AAK..BHZ"]) == 1
     assert v["II.AAK"]["II.AAK..BHZ"] == [{"left_index": 1, "right_index": 2}]
+    assert len(v["IU.BCD"]["IU.BCD..BHZ"]) == 2
+    assert v["IU.BCD"]["IU.BCD..BHZ"] == [{"left_index": 1, "right_index": 2},
+                                          {"left_index": 2, "right_index": 3}]
 
     assert m["II.AAK"] == {
-        "II.AAK..BHR": [{"dt": 1.0, "misfit_dt": 1.0},
-                        {"dt": -1.0, "misfit_dt": 1.0}],
-        "II.AAK..BHZ": [{"dt": 1.0, "misfit_dt": 1.0}]}
+        "II.AAK..BHR": [{"dt": 1.0, "misfit_dt": 1.0,
+                         "dlna": 0.7, "misfit_dlna": 1.0},
+                        {"dt": -1.0, "misfit_dt": 1.0,
+                         "dlna": -0.7, "misfit_dlna": 1.0}],
+        "II.AAK..BHZ": [{"dt": 1.0, "misfit_dt": 1.0,
+                         "dlna": 0.6, "misfit_dlna": 1.0}]}
     assert m["II.ABKT"] == {
-       "II.ABKT..BHR": [{"dt": 1.0, "misfit_dt": 1.5}]}
+       "II.ABKT..BHR": [{"dt": 1.0, "misfit_dt": 1.5,
+                         "dlna": 0.6, "misfit_dlna": 0.5}]}
     assert m["IU.BCD"] == {
-           "IU.BCD..BHR": [{"dt": 1.0, "misfit_dt": 2.0}],
-           "IU.BCD..BHT": [{"dt": 1.0, "misfit_dt": 2.0}],
-           "IU.BCD..BHZ": [{"dt": -0.2, "misfit_dt": 2.0},
-                           {"dt": 0.8, "misfit_dt": 3.0},
-                           {"dt": 0.9, "misfit_dt": 0.4}]}
+           "IU.BCD..BHT": [{"dt": 1.0, "misfit_dt": 2.0,
+                            "dlna": 0.3, "misfit_dlna": 0.2}],
+           "IU.BCD..BHZ": [{"dt": -0.2, "misfit_dt": 2.0,
+                            "dlna": -0.2, "misfit_dlna": 2.0},
+                           {"dt": 0.8, "misfit_dt": 3.0,
+                            "dlna": 0.8, "misfit_dlna": 0.6}]}
 
     bounds = {"R": [-0.1, 0.1], "T": [-0.1, 0.1], "Z": [-0.1, 0.1]}
     v, m = fw.filter_measurements_on_bounds(windows, measures, bounds)
@@ -167,40 +179,54 @@ def test_filter_windows_on_measurements():
     measure_config = \
         {"component": {
             "R": {"tshift_reference": 0, "tshift_acceptance_level": 10,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 4.0},
             "T": {"tshift_reference": 0, "tshift_acceptance_level": 10,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 4.0},
             "Z": {"tshift_reference": 0, "tshift_acceptance_level": 10,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 4.0}}}
 
     _wins, _meas = fw.filter_windows_on_measurements(
         windows, measures, measure_config)
     assert _wins["II.AAK"] == windows["II.AAK"]
-    assert _wins["IU.BCD"] == windows["IU.BCD"]
+    assert _wins["IU.BCD"]["IU.BCD..BHR"] == windows["IU.BCD"]["IU.BCD..BHR"]
+    assert _wins["IU.BCD"]["IU.BCD..BHT"] == windows["IU.BCD"]["IU.BCD..BHT"]
     assert _wins["II.ABKT"]["II.ABKT..BHR"] == \
         windows["II.ABKT"]["II.ABKT..BHR"]
-    assert _wins["II.ABKT"]["II.ABKT..BHZ"] == \
-        windows["II.ABKT"]["II.ABKT..BHZ"]
+    assert len(_wins["IU.BCD"]["IU.BCD..BHZ"]) == 4
     assert "II.ABKT..BHT" not in _wins["II.ABKT"]
+    assert "II.ABKT..BHZ" not in _wins["II.ABKT"]
     assert_wins_and_meas_same_length(_wins, _meas)
 
     measure_config = \
         {"component": {
             "R": {"tshift_reference": 0, "tshift_acceptance_level": 10.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 1.0},
             "T": {"tshift_reference": 0, "tshift_acceptance_level": 10.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 1.0},
             "Z": {"tshift_reference": 0, "tshift_acceptance_level": 10.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 1.0}}}
 
     _wins, _meas = fw.filter_windows_on_measurements(
         windows, measures, measure_config)
-    assert _wins["II.ABKT"]["II.ABKT..BHZ"] == \
+    assert _wins["II.AAK"]["II.AAK..BHR"] == \
         [{"left_index": 1, "right_index": 2}]
-    assert _wins["IU.BCD"]["IU.BCD..BHR"] == \
-        [{"left_index": 1, "right_index": 2}]
+    assert _wins["II.AAK"]["II.AAK..BHZ"] == \
+        [{"left_index": 1, "right_index": 2},
+         {"left_index": 2, "right_index": 3},
+         {"left_index": 3, "right_index": 4}]
     assert _wins["IU.BCD"]["IU.BCD..BHT"] == \
         [{"left_index": 1, "right_index": 2}]
+    assert _wins["IU.BCD"]["IU.BCD..BHZ"] == \
+        [{"left_index": 1, "right_index": 2},
+         {"left_index": 2, "right_index": 3},
+         {"left_index": 3, "right_index": 4},
+         {"left_index": 5, "right_index": 6}]
     assert_wins_and_meas_same_length(_wins, _meas)
 
 
@@ -209,10 +235,13 @@ def test_filter_windows_on_measurements_2():
     measure_config = \
         {"component": {
             "R": {"tshift_reference": 0, "tshift_acceptance_level": 0.1,
+                  "dlna_reference": 0, "dlna_acceptance_level": 0.1,
                   "std_ratio": 1.0},
             "T": {"tshift_reference": 0, "tshift_acceptance_level": 0.1,
+                  "dlna_reference": 0, "dlna_acceptance_level": 0.1,
                   "std_ratio": 1.0},
             "Z": {"tshift_reference": 0, "tshift_acceptance_level": 0.1,
+                  "dlna_reference": 0, "dlna_acceptance_level": 0.1,
                   "std_ratio": 1.0}}
          }
 
@@ -239,10 +268,13 @@ def test_filter_windows():
     measure_config = \
         {"component": {
             "R": {"tshift_reference": 0, "tshift_acceptance_level": 6.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 3.0},
             "T": {"tshift_reference": 0, "tshift_acceptance_level": 6.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 3.0},
             "Z": {"tshift_reference": 0, "tshift_acceptance_level": 6.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 3.0}},
          "flag": True}
 
@@ -253,34 +285,39 @@ def test_filter_windows():
     assert _wins["II.AAK"] == windows["II.AAK"]
     assert _wins["II.ABKT"]["II.ABKT..BHR"] == \
         windows["II.ABKT"]["II.ABKT..BHR"]
-    assert _wins["II.ABKT"]["II.ABKT..BHZ"] == \
-        windows["II.ABKT"]["II.ABKT..BHZ"]
+    assert "II.ABKT..BHZ" not in _wins["II.ABKT"]
     assert "II.ABKT..BHT" not in _wins["II.ABKT"]
     assert "IU.BCD" not in _wins["II.ABKT"]
 
     assert _meas["II.AAK"] == {
-        "II.AAK..BHR": [{"dt": 1.0, "misfit_dt": 1.0},
-                        {"dt": -1.0, "misfit_dt": 1.0}],
-        "II.AAK..BHT": [{"dt": 1.5, "misfit_dt": 2.5}],
-        "II.AAK..BHZ": [{"dt": 1.0, "misfit_dt": 1.0},
-                        {"dt": 2.0, "misfit_dt": 4.0},
-                        {"dt": -1.5, "misfit_dt": 3.00}]}
+        "II.AAK..BHR": [{"dt": 1.0, "misfit_dt": 1.0,
+                         "dlna": 0.7, "misfit_dlna": 1.0},
+                        {"dt": -1.0, "misfit_dt": 1.0,
+                         "dlna": -0.7, "misfit_dlna": 1.0}],
+        "II.AAK..BHT": [{"dt": 1.5, "misfit_dt": 2.5,
+                         "dlna": 0.9, "misfit_dlna": 0.5}],
+        "II.AAK..BHZ": [{"dt": 1.0, "misfit_dt": 1.0,
+                         "dlna": 0.6, "misfit_dlna": 1.0},
+                        {"dt": 2.0, "misfit_dt": 4.0,
+                         "dlna": 0.4, "misfit_dlna": 0.6},
+                        {"dt": -1.5, "misfit_dt": 3.00,
+                         "dlna": -0.5, "misfit_dlna": 1.0}]}
 
     assert _meas["II.ABKT"] == {
-        "II.ABKT..BHR": [{"dt": 1.0, "misfit_dt": 1.5}],
-        "II.ABKT..BHZ": [{"dt": 2.0, "misfit_dt": 4.0},
-                         {"dt": -5.0, "misfit_dt": 16.0}]}
+        "II.ABKT..BHR": [{"dt": 1.0, "misfit_dt": 1.5,
+                          "dlna": 0.6, "misfit_dlna": 0.5}]}
     assert_wins_and_meas_same_length(_wins, _meas)
 
+    print(log)
     _true_log = \
         {'sensor': {
-            'window_rejection_percentage': 50.0, 'nwindows_old': 18,
-            'channel_rejection_percentage': 37.5, 'nwindows_new': 9,
+            'window_rejection_percentage': '50.00', 'nwindows_old': 18,
+            'channel_rejection_percentage': '37.50', 'nwindows_new': 9,
             'nchannels_new': 5, 'nchannels_old': 8},
          'measurement': {
-             'window_rejection_percentage': 0.0, 'nwindows_old': 9,
-             'channel_rejection_percentage': 0.0, 'nwindows_new': 9,
-             'nchannels_new': 5, 'nchannels_old': 5}}
+             'window_rejection_percentage': '22.22', 'nwindows_old': 9,
+             'channel_rejection_percentage': '20.00', 'nwindows_new': 7,
+             'nchannels_new': 4, 'nchannels_old': 5}}
 
     assert log == _true_log
 
@@ -290,10 +327,13 @@ def test_filter_windows_2():
     measure_config = \
         {"component": {
             "R": {"tshift_reference": 0, "tshift_acceptance_level": 0.1,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 3.0},
             "T": {"tshift_reference": 0, "tshift_acceptance_level": 0.1,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 3.0},
             "Z": {"tshift_reference": 0, "tshift_acceptance_level": 0.1,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 3.0}},
          "flag": True}
 
@@ -308,10 +348,13 @@ def test_filter_windows_2():
     measure_config = \
         {"component": {
             "R": {"tshift_reference": 0, "tshift_acceptance_level": 10.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 0.01},
             "T": {"tshift_reference": 0, "tshift_acceptance_level": 10.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 0.01},
             "Z": {"tshift_reference": 0, "tshift_acceptance_level": 10.0,
+                  "dlna_reference": 0, "dlna_acceptance_level": 1.0,
                   "std_ratio": 0.01}},
          "flag": True}
     config = {"sensor": sensor_config, "measurement": measure_config}

--- a/pytomo3d/window/tests/test_filter_windows.py
+++ b/pytomo3d/window/tests/test_filter_windows.py
@@ -80,23 +80,41 @@ def test_filter_windows_on_sensor():
 
 
 def test_get_measurements_std():
-    means, stds = fw.get_measurements_std({})
-    assert len(means) == 0
-    assert len(stds) == 0
+    dt_means, dt_stds, dlna_means, dlna_stds = \
+        fw.get_measurements_std({})
+    assert len(dt_means) == 0
+    assert len(dt_stds) == 0
+    assert len(dlna_means) == 0
+    assert len(dlna_stds) == 0
 
-    means, stds = fw.get_measurements_std(measures)
-    _true_mean = \
+    dt_means, dt_stds, dlna_means, dlna_stds = \
+        fw.get_measurements_std(measures)
+
+   # from tests/data/window/measurements.fake.json
+    _true_dt_mean = \
         {"R": np.mean([1, -1, 1, 1, -2]),
          "T": np.mean([1, 1.5, -2.5]),
          "Z": np.mean([1, 2, -1.5, 2, -5, -0.2, 0.8, -1.6, 1.6, 0.9])}
-    _true_stds = \
+    _true_dt_stds = \
         {"R": np.std([1, -1, 1, 1, -2]),
          "T": np.std([1, 1.5, -2.5]),
          "Z": np.std([1, 2, -1.5, 2, -5, -0.2, 0.8, -1.6, 1.6, 0.9])}
 
+    _true_dlna_mean = \
+        {"R": np.mean([1.0, -1.0, 1.0, 1.0, -0.8]),
+         "T": np.mean([0.3, 0.3, -0.7]),
+         "Z": np.mean([0.6, 0.4, -0.5, 1.2, -1.5, -0.2, 0.8, -0.6, 1.1, 0.9])}
+    _true_dlna_stds = \
+        {"R": np.mean([1.0, -1.0, 1.0, 1.0, -0.8]),
+         "T": np.mean([0.3, 0.3, -0.7]),
+         "Z": np.mean([0.6, 0.4, -0.5, 1.2, -1.5, -0.2, 0.8, -0.6, 1.1, 0.9])}
+
     for comp in means:
-        npt.assert_array_almost_equal(means[comp], _true_mean[comp])
-        npt.assert_array_almost_equal(stds[comp], _true_stds[comp])
+        npt.assert_array_almost_equal(dt_means[comp], _true_dt_mean[comp])
+        npt.assert_array_almost_equal(dt_stds[comp], _true_dt_stds[comp])
+        npt.assert_array_almost_equal(dlna_means[comp], _true_dlna_mean[comp])
+        npt.assert_array_almost_equal(dlna_stds[comp], _true_dlna_stds[comp])
+
 
 
 def test_get_user_bound():

--- a/pytomo3d/window/tests/test_filter_windows.py
+++ b/pytomo3d/window/tests/test_filter_windows.py
@@ -90,7 +90,7 @@ def test_get_measurements_std():
     dt_means, dt_stds, dlna_means, dlna_stds = \
         fw.get_measurements_std(measures)
 
-   # from tests/data/window/measurements.fake.json
+    # from tests/data/window/measurements.fake.json
     _true_dt_mean = \
         {"R": np.mean([1, -1, 1, 1, -2]),
          "T": np.mean([1, 1.5, -2.5]),
@@ -114,7 +114,6 @@ def test_get_measurements_std():
         npt.assert_array_almost_equal(dt_stds[comp], _true_dt_stds[comp])
         npt.assert_array_almost_equal(dlna_means[comp], _true_dlna_mean[comp])
         npt.assert_array_almost_equal(dlna_stds[comp], _true_dlna_stds[comp])
-
 
 
 def test_get_user_bound():

--- a/tests/data/window/measurements.fake.json
+++ b/tests/data/window/measurements.fake.json
@@ -1,43 +1,43 @@
 {
   "II.AAK": {
     "II.AAK..BHR":[
-      {"dt": 1.0, "misfit_dt": 1.0},
-      {"dt": -1.0, "misfit_dt": 1.0}
+      {"dt": 1.0, "misfit_dt": 1.0, "dlna": 1.0, "misfit_dlna": 1.0},
+      {"dt": -1.0, "misfit_dt": 1.0, "dlna": -1.0, "misfit_dlna": 1.0}
     ],
     "II.AAK..BHT":[
-      {"dt": 1.5, "misfit_dt": 2.5}
+      {"dt": 1.5, "misfit_dt": 2.5, "dlna": 0.3, "misfit_dlna": 0.5}
     ],
     "II.AAK..BHZ":[
-      {"dt": 1.0, "misfit_dt": 1.0},
-      {"dt": 2.0, "misfit_dt": 4.0},
-      {"dt": -1.5, "misfit_dt": 3.00}
+      {"dt": 1.0, "misfit_dt": 1.0, "dlna": 0.6, "misfit_dlna": 1.0},
+      {"dt": 2.0, "misfit_dt": 4.0, "dlna": 0.4, "misfit_dlna": 0.6},
+      {"dt": -1.5, "misfit_dt": 3.00, "dlna": -0.5, "misfit_dlna": 1.0}
     ]
   },
   "II.ABKT": {
     "II.ABKT..BHR":[
-      {"dt": 1.0, "misfit_dt": 1.5}
+      {"dt": 1.0, "misfit_dt": 1.5, "dlna": 1.0, "misfit_dlna": 0.5}
     ],
     "II.ABKT..BHT":[],
     "II.ABKT..BHZ":[
-      {"dt": 2.0, "misfit_dt": 4.0},
-      {"dt": -5.0, "misfit_dt": 16.0}
+      {"dt": 2.0, "misfit_dt": 4.0, "dlna": 1.2, "misfit_dlna": 1.0},
+      {"dt": -5.0, "misfit_dt": 16.0, "dlna": -1.5, "misfit_dlna": 1.0}
     ]
   },
   "IU.BCD": {
     "IU.BCD..BHR":[
-      {"dt": 1.0, "misfit_dt": 2.0},
-      {"dt": -2.0, "misfit_dt": 3.0}
+      {"dt": 1.0, "misfit_dt": 2.0, "dlna": 1.0, "misfit_dlna": 1.5},
+      {"dt": -2.0, "misfit_dt": 3.0, "dlna": -0.8, "misfit_dlna": 1.2}
      ],
     "IU.BCD..BHT":[
-      {"dt": 1.0, "misfit_dt": 2.0},
-      {"dt": -2.5, "misfit_dt": 3.0}
+      {"dt": 1.0, "misfit_dt": 2.0, "dlna": 0.3, "misfit_dlna": 0.2},
+      {"dt": -2.5, "misfit_dt": 3.0, "dlna": -0.7, "misfit_dlna": 1.1}
     ],
     "IU.BCD..BHZ":[
-      {"dt": -0.2, "misfit_dt": 2.0},
-      {"dt": 0.8, "misfit_dt": 3.0},
-      {"dt": -1.6, "misfit_dt": 4.0},
-      {"dt": 1.6, "misfit_dt": 3.0},
-      {"dt": 0.9, "misfit_dt": 0.4}
+      {"dt": -0.2, "misfit_dt": 2.0, "dlna": -0.2, "misfit_dlna": 2.0},
+      {"dt": 0.8, "misfit_dt": 3.0, "dlna": 0.8, "misfit_dlna": 0.6},
+      {"dt": -1.6, "misfit_dt": 4.0, "dlna": -0.6, "misfit_dlna": 0.9},
+      {"dt": 1.6, "misfit_dt": 3.0, "dlna": 1.1, "misfit_dlna": 1.2},
+      {"dt": 0.9, "misfit_dt": 0.4, "dlna": 0.9, "misfit_dlna": 0.4}
     ]
   }
 }

--- a/tests/data/window/measurements.fake.json
+++ b/tests/data/window/measurements.fake.json
@@ -1,11 +1,11 @@
 {
   "II.AAK": {
     "II.AAK..BHR":[
-      {"dt": 1.0, "misfit_dt": 1.0, "dlna": 1.0, "misfit_dlna": 1.0},
-      {"dt": -1.0, "misfit_dt": 1.0, "dlna": -1.0, "misfit_dlna": 1.0}
+      {"dt": 1.0, "misfit_dt": 1.0, "dlna": 0.7, "misfit_dlna": 1.0},
+      {"dt": -1.0, "misfit_dt": 1.0, "dlna": -0.7, "misfit_dlna": 1.0}
     ],
     "II.AAK..BHT":[
-      {"dt": 1.5, "misfit_dt": 2.5, "dlna": 0.3, "misfit_dlna": 0.5}
+      {"dt": 1.5, "misfit_dt": 2.5, "dlna": 0.9, "misfit_dlna": 0.5}
     ],
     "II.AAK..BHZ":[
       {"dt": 1.0, "misfit_dt": 1.0, "dlna": 0.6, "misfit_dlna": 1.0},
@@ -15,7 +15,7 @@
   },
   "II.ABKT": {
     "II.ABKT..BHR":[
-      {"dt": 1.0, "misfit_dt": 1.5, "dlna": 1.0, "misfit_dlna": 0.5}
+      {"dt": 1.0, "misfit_dt": 1.5, "dlna": 0.6, "misfit_dlna": 0.5}
     ],
     "II.ABKT..BHT":[],
     "II.ABKT..BHZ":[


### PR DESCRIPTION
Add amplitude checks in window/filter_windows.py and window/tests/test_filter_windows.py, travel time and amplitude measurements in a time window need to satisfy criteria for both to pass the check.     